### PR TITLE
Prep for Archival

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Archival
+This repo was archived by the Apollo Security team on 2023-05-26
+
+Please reach out at security@apollographql.com with questions
+
+
 # githubble
 
 A tool for triaging GitHub issues.


### PR DESCRIPTION
This PR preps the repo for archival. It makes 2 changes if needed:
1. Updates readme with a note about archival
2. Defangs any CI config. This is done so that if the repo is ever restored, there are no surprise CI runs. To revert this change, rename the CI configuration folder back to its required name (`_github` -> `.github` OR `_circleci` -> `.circleci`) as appropriate.